### PR TITLE
GOB: remove detection headers from POTFILES

### DIFF
--- a/engines/gob/POTFILES
+++ b/engines/gob/POTFILES
@@ -3,10 +3,3 @@ engines/gob/inter_playtoons.cpp
 engines/gob/inter_v2.cpp
 engines/gob/inter_v5.cpp
 engines/gob/inter_v7.cpp
-engines/gob/detection/tables_adi1.h
-engines/gob/detection/tables_adi5.h
-engines/gob/detection/tables_adibou3.h
-engines/gob/detection/tables_adiboupresente.h
-engines/gob/detection/tables_adiboudchou.h
-engines/gob/detection/tables_nathanvacances.h
-engines/gob/detection/tables_pierresmagiques.h


### PR DESCRIPTION
Since we replaced the common/translation code with the MetaEngine code we no longer have to use _s() in the detection tables.
